### PR TITLE
[#88] zarr targets for drivers/obs

### DIFF
--- a/9_collaborator_data.yml
+++ b/9_collaborator_data.yml
@@ -156,6 +156,21 @@ targets:
       subnet_ind = '9_collaborator_data/umn/network_subset.rds.ind',
       out_ind = target_name)
 
+  9_collaborator_data/umn/obs_temp_subset.zarr.tar.ind:
+    command: write_zarr_tarfile(dat_ind = '9_collaborator_data/umn/obs_temp_subset.csv.ind', out_ind = target_name)
+    
+  9_collaborator_data/umn/obs_temp_full.zarr.tar.ind:
+    command: write_zarr_tarfile(dat_ind = '9_collaborator_data/umn/obs_temp_full.csv.ind', out_ind = target_name)
+
+  9_collaborator_data/umn/obs_flow_subset.zarr.tar.ind:
+    command: write_zarr_tarfile(dat_ind = '9_collaborator_data/umn/obs_flow_subset.csv.ind', out_ind = target_name)
+    
+  9_collaborator_data/umn/obs_flow_full.zarr.tar.ind:
+    command: write_zarr_tarfile(dat_ind = '9_collaborator_data/umn/obs_flow_full.csv.ind', out_ind = target_name)
+
+  9_collaborator_data/umn/uncal_sntemp_input_output.zarr.tar.ind:
+    command: write_zarr_tarfile(dat_ind = '3_predictions/out/uncal_sntemp_input_output.feather.ind', out_ind = target_name)
+
   9_collaborator_data/umn/obs_flow_subset_lordville.csv.ind:
     command: filter_subset(
       dat_ind = '2_observations/out/obs_flow_drb.rds.ind',

--- a/9_collaborator_data/src/write_functions.R
+++ b/9_collaborator_data/src/write_functions.R
@@ -46,3 +46,18 @@ save_dist_matrices <- function(dist_mat_ind, out_ind) {
 
 
 }
+
+write_zarr_tarfile <- function(dat_ind, out_ind){
+  out_file <- as_data_file(out_ind)
+  sys <- reticulate::import('sys', convert=FALSE)
+  position <- 0
+  position_int = as.integer(position)
+  sys$path$insert(position_int, '9_collaborator_data/src/')
+  write_py <- reticulate::import('write_functions_py')
+  data_file <- sc_retrieve(dat_ind, 'getters.yml')
+  write_py$write_zarr_tar(
+    data_file,
+    as_data_file(out_ind)
+  )
+  gd_put(out_ind)
+}

--- a/9_collaborator_data/src/write_functions_py.py
+++ b/9_collaborator_data/src/write_functions_py.py
@@ -1,0 +1,57 @@
+import os
+import shutil
+import pandas as pd
+import tarfile
+
+    
+def make_tar(in_flder, outfile):
+    with tarfile.open(f'{outfile}', 'w:gz') as tar:
+        tar.add(in_flder)
+
+
+def write_zarr_tar(data_file, out_tar=None, delete_zarr=True):
+    """
+    write a tar of a zarr store from a csv
+    :param data_file: csv file with columns 'seg_id_nat' and 'date'
+    :param out_tar: path that the tar file will be written to
+    :param delete_zarr: whether or not to delete the intermediate zarr store
+    """
+
+    # get filename extension
+    filepath, extension = os.path.splitext(data_file)
+
+    # get filename without extension
+    base, filename = os.path.split(filepath)
+
+    # specify zarr store name and tar name
+    zarr_storename = filename + ".zarr"
+    if not out_tar:
+        out_tar_filename = zarr_filename + ".tar"
+        out_tar = os.path.join(base, out_tar_filename) 
+
+    # read in data
+    if extension  == '.csv':
+        df = pd.read_csv(data_file)
+        df['date'] = pd.to_datetime(df['date'])
+    elif extension == '.feather':
+        df = pd.read_feather(data_file)
+    else:
+        raise ValueError('file must be feather or csv')
+    if 'subseg_id' in df.columns:
+        del df['subseg_id']
+
+    # set indices
+    ds = df.set_index(['seg_id_nat', 'date']).to_xarray()
+    ds['seg_id_nat'] = ds.seg_id_nat.astype(int)
+
+    # Write out an intermediate zarr file before making it a tar
+    ds.chunk({'seg_id_nat': len(ds.seg_id_nat),
+              'date': len(ds.date)}).to_zarr(zarr_storename, mode='w')
+
+    # write tar
+    make_tar(zarr_filename, out_tar)
+
+    # delete zarr
+    if delete_zarr:
+        shutil.rmtree(zarr_filename)
+


### PR DESCRIPTION
making zarr targets for 
- `uncal_sntemp_input_output.feather`
- `obs_[flow, temp]_[full, subset].csv`

A few things to highlight that are up for adjustment:

## not including in depends
I didn't add these to the top-level `depends` because I didn't know if they needed to be built for everyone. Similarly I did not add to the `getters.yml. That said, I was able to build these targets locally. 

## `tar` files instead of zarr directory
The targets are actually making a *tar* file of the zarr directory. 
- I found this easier to deal with as far as moving the data - moving one `tar` file is often easier than moving a directory of multiple files. 
- This also feels more natural for dealing with in Scipiper. 
- The drawback is that it leaves one more step - the untarring step - to the user

## using a python script
This is the first time I've tried to tie a python function into a scipiper workflow. The integration was pretty smooth. One question that still will need to be answered is how to get the correct python environment. I suppose I could add an `environment.yml` file that specifies the python environment.

