### PR TITLE
Keep raw temperature data matched to segments

### DIFF
--- a/2_observations.yml
+++ b/2_observations.yml
@@ -79,17 +79,22 @@ targets:
   # temperature observations that have been filtered to crosswalk
   # this represent all DRB dat
   2_observations/out/all_drb_temp_obs.rds.ind:
-    command: filter_temp_data(
+    command: filter_temp_data_to_crosswalk(
       dat_ind = '2_observations/in/daily_temperatures_qaqc.rds.ind',
       cross_ind = '2_observations/out/crosswalk_site_reach.rds.ind',
       out_ind = target_name)
 
-  # keep only data in the filtered sites above,
-  # and take mean of multiple obs/reach-dat to reduce duplicate vals
-  2_observations/out/obs_temp_drb.rds.ind:
-    command: munge_split_temp_dat(
+  # keep only data in the filtered sites above
+  2_observations/out/obs_temp_drb_raw.rds.ind:
+    command: filter_temp_data_to_sites(
       sites_ind = '2_observations/out/drb_filtered_sites.rds.ind',
       dat_ind = '2_observations/out/all_drb_temp_obs.rds.ind',
+      out_ind = target_name)
+
+  # take mean of multiple obs/reach-dat to reduce duplicate vals
+  2_observations/out/obs_temp_drb.rds.ind:
+    command: munge_split_temp_dat(
+      dat_ind = '2_observations/out/obs_temp_drb_raw.rds.ind',
       holdout_water_years = holdout_water_years,
       holdout_reach_ids = holdout_reach_ids,
       out_ind = target_name)


### PR DESCRIPTION
This PR addresses our need to keep the raw, unaggregated temperature data matched to PRMS segments (in addition to the aggregated values that we currently use to represent 1 value/segment-day). The code changes here take the following steps:

- create a new target (`2_observations/out/obs_temp_drb_raw.rds.ind`) to store the raw data that has been filtered to the set of useable sites
- move the code chunks that filter the temperature data to the set of useable sites from `munge_split_temp_dat()` to a new function `filter_temp_data_to_sites()`. To me, this seemed like the most straightforward way to save the raw temperature data before we aggregate it by segment id. 
- edit the target `2_observations/out/obs_temp_drb.rds.ind` so that it depends on the new raw data target as input to `dat_ind`.


The changes described above add a new target and make the `munge_split_temp_dat()` function more modular, but I have not yet made any changes to _how_ we aggregate the temperature data and so the output for `2_observations/out/obs_temp_drb.rds.ind` should be the same as what's on google drive. I haven't run the pipeline by calling `sc_make()` because I didn't want to edit any of the files while Sam was also working in the shared data cache. So as a test, here's how I validated the output:

Modify each of the functions a bit by replacing the {scipiper} functions with `readRDS()` or `return()`
```
filter_temp_data_to_sites <- function(sites_ind, dat_ind){

  sites <- readRDS(sites_ind) %>%
    select(site_id, subseg_id, seg_id_nat) %>%
    distinct()

  dat <- readRDS(dat_ind)
  drb_dat <- filter(dat, site_id %in% unique(sites$site_id)) %>%
    distinct(site_id, date, mean_temp_degC, .keep_all = TRUE) %>%
    group_by(site_id, date) %>%
    summarize(mean_temp_C = round(mean(mean_temp_degC), 1),
              min_temp_C = min(min_temp_degC),
              max_temp_C = max(max_temp_degC)) %>%
    ungroup() %>%
    left_join(sites, by = "site_id")

  return(drb_dat)
}

munge_split_temp_dat <- function(drb_dat, holdout_water_years,
                                 holdout_reach_ids) {
  drb_dat_by_subseg <- drb_dat %>%
    group_by(subseg_id, seg_id_nat, date) %>%
    summarize(mean_temp_c = round(mean(mean_temp_C), 1),
              min_temp_c = min(min_temp_C),
              max_temp_c = max(max_temp_C),
              site_id = paste0(site_id, collapse = ', ')) %>%
    ungroup() %>%
    mark_time_space_holdouts(holdout_water_years, holdout_reach_ids)

  return(drb_dat_by_subseg)
}
```

Download the current filtered/munged temp data from google drive
```
gd_get('2_observations/out/obs_temp_drb.rds.ind')
> obs_temp_drb_gd <- readRDS('2_observations/out/obs_temp_drb.rds')
> dim(obs_temp_drb_gd)
[1] 490438     10
```

Create the equivalent target using the functions modified in this PR
```
> obs_temp_raw <- filter_temp_data_to_sites(
+   sites_ind = '2_observations/out/drb_filtered_sites.rds',
+   dat_ind = '2_observations/out/all_drb_temp_obs.rds'
+ )
`summarise()` has grouped output by 'site_id'. You can override using the `.groups` argument.

> obs_temp_drb <- munge_split_temp_dat(
+   drb_dat = obs_temp_raw,
+   holdout_water_years = holdout_water_years,
+   holdout_reach_ids = holdout_reach_ids
+ )
`summarise()` has grouped output by 'subseg_id', 'seg_id_nat'. You can override using the `.groups` argument.

> dim(obs_temp_drb)
[1] 490438     10
> all.equal(obs_temp_drb_gd, obs_temp_drb)
[1] TRUE
> 
```

I'm open to any feedback you have, including target/function names. I'm also hoping you can test out the scipiper functionality to make sure all of the targets build as expected based on my pseudo-code above. Thanks!

