### PR TITLE
Prioritize NWIS sites when aggregating temp data

### DIFF
--- a/2_observations.yml
+++ b/2_observations.yml
@@ -97,7 +97,8 @@ targets:
       dat_ind = '2_observations/out/obs_temp_drb_raw.rds.ind',
       holdout_water_years = holdout_water_years,
       holdout_reach_ids = holdout_reach_ids,
-      out_ind = target_name)
+      out_ind = target_name,
+      prioritize_nwis_sites = TRUE)
 
 
   priority_sites:

--- a/2_observations/src/data_munge_functions.R
+++ b/2_observations/src/data_munge_functions.R
@@ -74,17 +74,29 @@ water_year_to_days <- function(year) {
       to = as.POSIXct(paste0(year, "-09-30"), tz = 'UTC'), by="+1 day")
 }
 
+
+#' @param prioritize_nwis_sites logical; indicates whether segment summaries should
+#' prioritize NWIS observations when available. Defaults to TRUE. If TRUE, any
+#' observations from non-NWIS sites will be omitted from the summarized data.
 munge_split_temp_dat <- function(dat_ind, holdout_water_years,
-                           holdout_reach_ids, out_ind) {
+                           holdout_reach_ids, out_ind, prioritize_nwis_sites = TRUE) {
 
   drb_dat <- readRDS(sc_retrieve(dat_ind, 'getters.yml'))
 
   drb_dat_by_subseg <- drb_dat %>%
     group_by(subseg_id, seg_id_nat, date) %>%
+    # If prioritize_nwis_sites is TRUE, check whether data for that segment
+    # comes from multiple sources. If multiple distinct site id's, retain only
+    # NWIS sites for that segment-date; otherwise, retain all samples
+    {if(prioritize_nwis_sites){
+      filter(., if(n_distinct(site_id) > 1) grepl("USGS", site_id, ignore.case = TRUE) else TRUE)
+    } else {.}
+    } %>%
     summarize(mean_temp_c = round(mean(mean_temp_C), 1),
               min_temp_c = min(min_temp_C),
               max_temp_c = max(max_temp_C),
-              site_id = paste0(site_id, collapse = ', ')) %>%
+              site_id = paste0(site_id, collapse = ', '),
+              .groups = 'keep') %>%
     ungroup() %>%
     mark_time_space_holdouts(holdout_water_years, holdout_reach_ids)
 


### PR DESCRIPTION
This PR addresses high maximum temperature observations at Lordville during summer 2015 (detailed in https://code.usgs.gov/wma/wp/pump-temperature/-/issues/27). 

A solution described in the issue linked above was to prioritize data from long term monitoring sites (NWIS) when there are multiple observations per segment-day. The code changes here add an argument, `prioritize_nwis_sites`, to `munge_split_temp_dat()` in 2_observations/src/data_munge_functions.R. If `prioritize_nwis_sites = TRUE`, selectively retain NWIS/"USGS" monitoring locations when aggregating observations from different sites.

I haven't run the pipeline by calling sc_make() because I didn't want to edit any of the files while Sam was also working in the shared data cache. But here is a preview of the output for the Lordville segment (seg_id_nat = 1573), narrowing in on 2015, if `prioritize_nwis_sites` is TRUE:

![lordville](https://user-images.githubusercontent.com/8785034/163279031-e27bf432-cfe4-4774-9093-8d73d1e47835.png)

and looking at an example for just one day (2015-05-23):
```
# A tibble: 1 x 8
# Groups:   subseg_id, seg_id_nat, date [1]
  site_id       date                mean_temp_C min_temp_C max_temp_C subseg_id seg_id_nat  year
  <chr>         <dttm>                    <dbl>      <dbl>      <dbl> <chr>          <int> <dbl>
1 USGS-01427207 2015-05-23 00:00:00        14.6       12.6       16.7 139_1           1573  2015
> 
```

In comparison, if `prioritize_nwis_sites` is FALSE, we also use the NYDEC data to estimate daily min/mean/max for the segment:

![lordville_old](https://user-images.githubusercontent.com/8785034/163279597-93b78c30-c54c-4b22-b08f-2c33d52a243a.png)


```
# A tibble: 3 x 8
# Groups:   subseg_id, seg_id_nat, date [1]
  site_id                     date                mean_temp_C min_temp_C max_temp_C subseg_id seg_id_nat  year
  <chr>                       <dttm>                    <dbl>      <dbl>      <dbl> <chr>          <int> <dbl>
1 NYDEC-Delaware River D1     2015-05-23 00:00:00        14.5       12.2       16.8 139_1           1573  2015
2 NYDEC-Delaware River Site 2 2015-05-23 00:00:00        15.1        9.7       23.6 139_1           1573  2015
3 USGS-01427207               2015-05-23 00:00:00        14.6       12.6       16.7 139_1           1573  2015
>
```

To implement this code change we look for site_id's that contain "USGS". In looking through many site_id's it seemed reasonable to assume that all NWIS monitoring locations would contain "USGS" in the `site_id` field. Let me know if you think that might not be the case. Thanks!
